### PR TITLE
update to Polymer 2.0 slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Localize text with HTML elements using [app-localize-behavior](https://github.co
 locales.json
 ```json
 {
-"text": "<a href=\"/settings\">Settings</a>"
+"text": "<span>Settings</a>"
 }
 ```
 
@@ -22,12 +22,12 @@ HTML
 
 ### Example 2
 
-Using `span` element for content styled with CSS.
+Using element content styled with CSS.
 
 locales.json
 ```json
 {
-"text": "<a class=\"red\" href=\"/settings\">Settings</a>"
+"text": "<span class=\"red\">Settings</span>"
 }
 ```
 
@@ -40,10 +40,33 @@ CSS
 
 HTML
 ```html
-<s-html html="[[localize('text')]]"><span></span></s-html>
+<s-html html="[[localize('text')]]"></s-html>
 ```
 
 ### Example 3
+
+Using element content styled with CSS within an element.
+
+locales.json
+```json
+{
+"text": "<span class=\"red\">Settings</span>"
+}
+```
+
+CSS
+```css
+.red {
+  color: red;
+}
+```
+
+HTML
+```html
+<s-html html="[[localize('text')]]"><custom-element></custom-element></s-html>
+```
+
+### Example 4
 
 Unescape escaped HTML elements.
 
@@ -61,8 +84,8 @@ HTML
 
 ## Installation
 
-`bower i s-html -S`
+`bower i uxland/s-html -S`
 
 ## License
 
-MIT: [StartPolymer/license](https://github.com/StartPolymer/license)
+Apache 2.0

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,13 @@
 {
   "name": "s-html",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "Element wrapper of `.innerHTML` for data binding with HTML elements.",
-  "authors": [
-    "The StartPolymer Project Authors (https://github.com/StartPolymer/authors)"
+   "authors": [
+    {
+      "name": "UXLand",
+      "email": "dev@uxland.es",
+      "homepage": "http://www.uxland.es"
+    }
   ],
   "keywords": [
     "web-components",
@@ -14,20 +18,19 @@
     "innerHTML"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0"
+    "polymer": "Polymer/polymer#^2.0.0"
   },
   "license": "MIT",
   "main": "s-html.html",
   "repository": {
     "type": "git",
-    "url": "git://github.com/StartPolymer/s-html.git"
+    "url": "git://github.com/uxland/s-html.git"
   },
   "devDependencies": {
     "paper-styles": "PolymerElements/paper-styles#^1.0.4",
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "test-fixture": "polymerelements/test-fixture#^1.0.0",
-    "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "ignore": []
 }

--- a/s-html.html
+++ b/s-html.html
@@ -30,7 +30,7 @@ Polymer({
 
   properties: {
     /**
-     * HTML template string.
+     * Text with HTML elements.
      */
     html: {
       type: String,
@@ -56,7 +56,8 @@ Polymer({
     if (child) {
       Polymer.dom(child).innerHTML = html;
     } else {
-      Polymer.dom(this.root).innerHTML = html;
+
+      Polymer.dom(this).innerHTML = html;
     }
   },
 

--- a/s-html.html
+++ b/s-html.html
@@ -19,7 +19,7 @@ The complete set of contributors may be found at https://github.com/StartPolymer
 
 </style>
 
-<content select="span"></content>
+<slot></slot>
 
 </template>
 <script>
@@ -47,7 +47,7 @@ Polymer({
   },
 
   _htmlChanged: function(html) {
-    var child = Polymer.dom(this).queryDistributedElements('span')[0];
+    var child = Polymer.dom(this).children[0];
 
     if (this.unescape) {
       html = this._unescapeHtml(html);

--- a/s-html.html
+++ b/s-html.html
@@ -30,7 +30,7 @@ Polymer({
 
   properties: {
     /**
-     * Text with HTML elements.
+     * HTML template string.
      */
     html: {
       type: String,


### PR DESCRIPTION
Replace Polymer 1.0 <content> with Polymer 2.0 <slot>.
Allow to encapsulate html in any kind of element (before it was restricted to 'span').